### PR TITLE
bugfix: hitting save multiple times no longer sets credits to 0

### DIFF
--- a/include/classes/elements/LiElement.inc
+++ b/include/classes/elements/LiElement.inc
@@ -936,7 +936,7 @@ class LiElement extends Element{
 
     $this->loadUserData4( $_POST['TEAM'] ); // loads the dynamic data from the working table.
 
-    if ( $this->isStartOver() ){// start over without commenting
+    if ( !isset($_POST['CREDITS']) ){ // quick correction is used
       //makeLogEntry( 'i', 'quick correcting', $this->idx );
       $GLOBALS['Logger']->logToDatabase($_POST['FULLADDRESS'], logActions::iCorrectorQuick, $_POST['TEAM']);
       $_POST['CREDITS'] = (isset($_POST['FULL_CREDITS'.$this->idx]) ? $this->possibleCredits : $this->givenCredits);


### PR DESCRIPTION
The function isStartOver() incorrectly returns false when the corrector
clicks "save" again when the "isCorrected" state was already updated in
the database (but the corrector's page was not reloaded)

Just checking if CREDITS is undefined and defining it if necessary
should be sufficient and fix the bug.