### PR TITLE
always use the mysql server's default engine

### DIFF
--- a/php/forTest.sql
+++ b/php/forTest.sql
@@ -28,7 +28,7 @@ CREATE TABLE `input_answers` (
   `corrected` tinyint(1) default '0',
   `history` text NOT NULL,
   PRIMARY KEY  (`idx`)
-) TYPE=MyISAM AUTO_INCREMENT=3 ;
+) AUTO_INCREMENT=3 ;
 
 -- 
 -- Daten für Tabelle `input_answers`
@@ -51,7 +51,7 @@ CREATE TABLE `input_answers_locks` (
   `lock_on_idx` bigint(20) default NULL,
   `history` text NOT NULL,
   PRIMARY KEY  (`idx`)
-) TYPE=MyISAM AUTO_INCREMENT=3 ;
+) AUTO_INCREMENT=3 ;
 
 -- 
 -- Daten für Tabelle `input_answers_locks`
@@ -72,7 +72,7 @@ CREATE TABLE `input_answers_uid_team` (
   `team` int(9) default NULL,
   `history` text NOT NULL,
   PRIMARY KEY  (`idx`)
-) TYPE=MyISAM AUTO_INCREMENT=3 ;
+) AUTO_INCREMENT=3 ;
 
 -- 
 -- Daten für Tabelle `input_answers_uid_team`
@@ -105,7 +105,7 @@ CREATE TABLE `lab_uid_status` (
   `lab_possible_credits` int(11) default '0',
   `history` text NOT NULL,
   PRIMARY KEY  (`idx`)
-) TYPE=MyISAM AUTO_INCREMENT=2 ;
+) AUTO_INCREMENT=2 ;
 
 -- 
 -- Daten für Tabelle `lab_uid_status`
@@ -128,7 +128,7 @@ CREATE TABLE `multiple_choice_answers` (
   `answer_array` text,
   `history` text NOT NULL,
   PRIMARY KEY  (`idx`)
-) TYPE=MyISAM AUTO_INCREMENT=2 ;
+) AUTO_INCREMENT=2 ;
 
 -- 
 -- Daten für Tabelle `multiple_choice_answers`
@@ -153,7 +153,7 @@ CREATE TABLE `schedules` (
   `comment` text NOT NULL,
   `history` text NOT NULL,
   PRIMARY KEY  (`idx`)
-) TYPE=MyISAM AUTO_INCREMENT=3 ;
+) AUTO_INCREMENT=3 ;
 
 -- 
 -- Daten für Tabelle `schedules`
@@ -178,7 +178,7 @@ CREATE TABLE `user_rights` (
   `history` text NOT NULL,
   PRIMARY KEY  (`idx`),
   KEY `uid` (`uid`)
-) TYPE=MyISAM AUTO_INCREMENT=3 ;
+) AUTO_INCREMENT=3 ;
 
 -- 
 -- Daten für Tabelle `user_rights`

--- a/setup/sql_new_ddb_pages_tbl.sql
+++ b/setup/sql_new_ddb_pages_tbl.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `pages` (
   `visible_only_in_collection` tinyint(1) DEFAULT '0',
   `history` text NOT NULL,
   PRIMARY KEY (`idx`)
-) ENGINE=MyISAM AUTO_INCREMENT=18 ;
+) AUTO_INCREMENT=18 ;
 
 INSERT INTO `pages` (`idx`, `title`, `contents`, `matching_menu`, `visible_for`, `visible_only_in_collection`, `history`) VALUES
 (1, 'prototype page element', '[HTML]\r\n<!-- click on the icon with the eye (second one) on the upper right to see how this page looks like! -->\r\n\r\n<h3>__ELEMENTTITLE__</h3>\r\n\r\n<p>\r\n<b>Hello __FORENAME__ __NAME__</b> (__USERNAME__), at the moment you watch the prototype of a page element!\r\n</p>\r\n\r\n<p>\r\nWhen you create new pages, this template will be used by default.\r\n</p>\r\n<p>\r\nYou can change it as you like, you can even have multiple templates...<br />\r\nThey can be managed <a href="../pages/view.php?address=p2&__LINKQUERY__">here <img src="../syspix/button_manage_elements_13x12.gif" width="13" height="12" border="0"></a>...\r\n</p>\r\n\r\n<p>\r\nTo get back to the edit mode just click <a href="../pages/edit.php?address=p1&__LINKQUERY__"><img src="../syspix/button_edit_13x12.gif" width="13" height="12" border="0"></a> here or on the top right...\r\n</p>', '', 1, 1, '2006-03-11 19:10:58: Marc-Oliver Pahl'),

--- a/setup/sql_new_wdb_event_log_tbl.sql
+++ b/setup/sql_new_wdb_event_log_tbl.sql
@@ -7,4 +7,4 @@ CREATE TABLE IF NOT EXISTS `event_log` (
 `action` INT NOT NULL ,
 `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ,
 PRIMARY KEY (  `idx` )
-) ENGINE = MYISAM COMMENT =  'Saves the event log for the actions within the labsystem.';
+) COMMENT =  'Saves the event log for the actions within the labsystem.';

--- a/setup/sql_new_wdb_ur_tbl.sql
+++ b/setup/sql_new_wdb_ur_tbl.sql
@@ -7,4 +7,4 @@ CREATE TABLE IF NOT EXISTS `user_rights` (
   `history` text NOT NULL,
   PRIMARY KEY (`idx`),
   KEY `uid` (`uid`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;


### PR DESCRIPTION
newly created instances should always use the server's default database,
which is expceted to be both performant and stable