### PR TITLE
Preface, content and schedule can now be manually placed in the according subsection of the menu

### DIFF
--- a/include/helper.inc
+++ b/include/helper.inc
@@ -269,6 +269,32 @@ function removeFromArray($array, $key) {
   unset($array[$key]);
   return $array;
 }
+
+/**
+ * Replaces the key of a value in an array with a new key while preserving order of the array.
+ * @param $array $array The array to change
+ * @param $value $value The value of the key that should be replaced
+ * @param $key $new_key The new key that should be set for the given value
+ * @return array The array with the new key
+ */
+function replace_key_of_value($array, $value, $new_key) {
+    //if the array doesn't contain the value just return it without change.
+    if (!in_array($value, $array)) {
+        return $array;
+    }
+    
+    //find old key
+    $old_key = array_search ($value, $array,true);
+    //get all keys of the array
+    $keys = array_keys($array);
+
+    //replace the old_key with new_key
+    $keys[array_search($old_key, $keys)] = $new_key;
+
+    //combine the keys and values again
+    return array_combine($keys, array_values($array));
+}
+
 /**
  * These links are used for the arrow navigation in /include/page_layout.inc at the bottom.
  * They are set by EB::prev, EB::next, and EB::TOC.

--- a/include/helper.inc
+++ b/include/helper.inc
@@ -271,13 +271,13 @@ function removeFromArray($array, $key) {
 }
 
 /**
- * Replaces the key of a value in an array with a new key while preserving order of the array.
+ * Renames the key of a value in an array with a new key while preserving order of the array.
  * @param $array $array The array to change
  * @param $value $value The value of the key that should be replaced
  * @param $key $new_key The new key that should be set for the given value
  * @return array The array with the new key
  */
-function replace_key_of_value($array, $value, $new_key) {
+function renameKeyInArray($array, $value, $new_key) {
     //if the array doesn't contain the value just return it without change.
     if (!in_array($value, $array)) {
         return $array;

--- a/include/menu.inc
+++ b/include/menu.inc
@@ -76,12 +76,17 @@ foreach ( $mainMenuIni as $key => &$value ){
     }
 
     // Possibly preface
-    if ($cfg->doesExist('prefaceID') && $cfg->get('prefaceID')!=''){
+    if ($cfg->doesExist('prefaceID') && $cfg->get('prefaceID')!='' && !in_array('!'.$cfg->get('prefaceID'), $value)){
       array_push( $value, '!'.$cfg->get('prefaceID') );
     }
 
-    // Menu from overview page -START-
-    $value[ $lng->get('MnuEntryCourseContent') ] = '../pages/accessibleLabs.php';
+    if (!in_array("../pages/accessibleLabs.php", $value)){
+      // Menu from overview page -START-
+      $value[ $lng->get('MnuEntryCourseContent') ] = '../pages/accessibleLabs.php';
+    } else {
+      //if the element was assigned manually we have to set the key accordingly, otherwise the key set in the menu.ini would be used.
+      $value=replace_key_of_value($value, "../pages/accessibleLabs.php", $lng->get( "MnuEntryCourseContent" ));
+    }
 
     // Collect all visible labs in the order:
     //   - Visible labs without schedule.
@@ -99,7 +104,13 @@ foreach ( $mainMenuIni as $key => &$value ){
     // Menu from overview page -STOP-
 
     array_push( $value, '' ); // spacer
-    $value[$lng->get( "MnuEntrySchedule" )]="../pages/view.php?address=s1"; // schedule
+    if (!in_array("../pages/view.php?address=s1", $value)){   
+      $value[$lng->get( "MnuEntrySchedule" )]="../pages/view.php?address=s1"; // schedule
+      
+    } else {
+      //if the element was assigned manually we have to set the key accordingly, otherwise the key set in the menu.ini would be used.
+      $value=replace_key_of_value($value, "../pages/view.php?address=s1", $lng->get( "MnuEntrySchedule" ));
+    }
   }
 
   if ( $key == "edit_menu" && $usr->isOfKind( IS_CONTENT_EDITOR )){

--- a/include/menu.inc
+++ b/include/menu.inc
@@ -85,7 +85,7 @@ foreach ( $mainMenuIni as $key => &$value ){
       $value[ $lng->get('MnuEntryCourseContent') ] = '../pages/accessibleLabs.php';
     } else {
       //if the element was assigned manually we have to set the key accordingly, otherwise the key set in the menu.ini would be used.
-      $value=replace_key_of_value($value, "../pages/accessibleLabs.php", $lng->get( "MnuEntryCourseContent" ));
+      $value=renameKeyInArray($value, "../pages/accessibleLabs.php", $lng->get( "MnuEntryCourseContent" ));
     }
 
     // Collect all visible labs in the order:
@@ -109,7 +109,7 @@ foreach ( $mainMenuIni as $key => &$value ){
       
     } else {
       //if the element was assigned manually we have to set the key accordingly, otherwise the key set in the menu.ini would be used.
-      $value=replace_key_of_value($value, "../pages/view.php?address=s1", $lng->get( "MnuEntrySchedule" ));
+      $value=renameKeyInArray($value, "../pages/view.php?address=s1", $lng->get( "MnuEntrySchedule" ));
     }
   }
 


### PR DESCRIPTION
#86 
If preface, content or schedule are manually placed in the menu.ini config, they are now only placed at their manual position and don't appear twice.